### PR TITLE
Fix double .value in noise calculation

### DIFF
--- a/pycprops/pycprops.py
+++ b/pycprops/pycprops.py
@@ -42,12 +42,12 @@ def fits2props(cube_file,
 
     if allow_huge:
       s.allow_huge_operations = True
-    
+
     if noise_file is None:
         print("No noise file found.  Calculating noise from Med. Abs. Dev of Data")
         noise = s.mad_std().value
         if delta is None:
-            delta = 2 * noise.value
+            delta = 2 * noise
     else:
         noise = SpectralCube.read(datadir + '/' +noise_file)
         if delta is None:
@@ -59,9 +59,9 @@ def fits2props(cube_file,
     nanmask = np.isnan(mask)
     mask = mask.astype(np.bool)
     mask[nanmask] = False
-    
+
     s = s.with_mask(mask)
-    
+
     if asgn is None:
         asgn = cube_decomp(s, delta=delta, verbose=verbose,
                            **kwargs)
@@ -74,5 +74,5 @@ def fits2props(cube_file,
                        alphaCO=alphaCO,
                        channelcorr=channelcorr,
                        **kwargs)
-    
+
     props.write(output_directory + '/' + propsname, overwrite=True)

--- a/pycprops/pycprops.py
+++ b/pycprops/pycprops.py
@@ -29,6 +29,7 @@ def fits2props(cube_file,
                verbose=True,
                alphaCO=6.7,
                channelcorr=0.0,
+               allow_huge=False,
                asgn=None, **kwargs):
 
     if asgnname is None:
@@ -39,6 +40,9 @@ def fits2props(cube_file,
     s = SpectralCube.read(datadir + '/' + cube_file)
     mask = fits.getdata(datadir + '/' + mask_file)
 
+    if allow_huge:
+      s.allow_huge_operations = True
+    
     if noise_file is None:
         print("No noise file found.  Calculating noise from Med. Abs. Dev of Data")
         noise = s.mad_std().value


### PR DESCRIPTION
The automatic noise calculation from the input cube fails due to an astropy.units error if no noise file is given and delta==None.
The reason is noise being a float already, so noise.value fails:

```
pycprops.fits2props('file.fits',
                    mask_file  = 'mask.fits',
                    distance   = 1.0*u.Mpc,
                    asgnname   = 'assignment.fits',
                    propsname  = 'props.fits'
                   )
```

```
fits2props(cube_file, datadir, output_directory, mask_file, noise_file, distance, asgnname, propsname, delta, verbose, alphaCO, channelcorr, allow_huge, asgn, **kwargs)
     48         noise = s.mad_std().value
     49         if delta is None:
---> 50             delta = 2 * noise.value
     51     else:
     52         noise = SpectralCube.read(datadir + '/' +noise_file)

AttributeError: 'float' object has no attribute 'value'
```